### PR TITLE
Disk platter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Progress: 80% [xxxxxxxx  ]
     - [ ] Raw Circuit Board spannender (Botania Farbe, Crafting Components Blueprint im IE Table, Copper, Clay)
     - [ ] Cutting Wire vollständig entfernen
     - [ ] Diamond Chips über Crusher
-    - [ ] Discs über Embers Stamper Gear Stamp (Aluminium Plates + Molten Cobalt)
+    - [X] Discs über Embers Stamper Gear Stamp (Aluminium Plates + Molten Cobalt)
     - [ ] Transistor IE Table (8 Stück: Silicon, Iron, Gold Nugget, Redstone)
     - [ ] Grog ändern und dann Slime über Stamp und Grog
 - [ ] Storage Drawers anschauen

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Progress: 80% [xxxxxxxx  ]
     - [ ] Raw Circuit Board spannender (Botania Farbe, Crafting Components Blueprint im IE Table, Copper, Clay)
     - [ ] Cutting Wire vollständig entfernen
     - [ ] Diamond Chips über Crusher
-    - [ ] Discs über Embers Stamper Gear Stamp (Aluminium Plates + Molten Glass)
+    - [ ] Discs über Embers Stamper Gear Stamp (Aluminium Plates + Molten Cobalt)
     - [ ] Transistor IE Table (8 Stück: Silicon, Iron, Gold Nugget, Redstone)
     - [ ] Grog ändern und dann Slime über Stamp und Grog
 - [ ] Storage Drawers anschauen

--- a/scripts/opencomputers.zs
+++ b/scripts/opencomputers.zs
@@ -1,0 +1,3 @@
+//disc platter recipe
+recipes.remove(<opencomputers:material:12>);
+mods.embers.Stamper.add(<opencomputers:material:12>, <liquid:cobalt> * 12, <embers:stamp_gear>, <ore:plateAluminum>);


### PR DESCRIPTION
During rewatching the stream the fact that the hard disk drive platters will be crafted from only non magnetic materials really triggered me. How could it be that a magentic storage medium is crafted with non-magnetic materials?

[As wikipedia states:](https://en.wikipedia.org/wiki/Hard_disk_drive_platter) 
> The material of the main magnetic medium layer is usually a cobalt-based alloy. 
> _[...]_
> Platters are typically made using an aluminium, glass or ceramic substrate.
>  As of 2015, laptop hard drive platters are made from glass while aluminum platters are often found in desktop computers.
>  In disk manufacturing, a thin coating is deposited on both sides of the substrate, mostly by a [vacuum deposition](https://en.wikipedia.org/wiki/Vacuum_deposition) process called magnetron [sputtering](https://en.wikipedia.org/wiki/Sputter_deposition). 
> The coating has a complex layered structure consisting of various metallic (mostly non-magnetic) alloys as underlayers, optimized for the control of the crystallographic orientation and the grain size of the actual magnetic media layer on top of them.

So the most realistic step is to craft the discs out of aluminium plates and a tiny amount of cobalt.  
This has the additional side effect that it requires you to play through tinkers construct and botania till you get access to cobalt.  

I created the following recipe:

![recipe](https://user-images.githubusercontent.com/17405009/117858532-4359f080-b28e-11eb-8681-4f182edae526.gif)

The recipe requires 1 cobalt ingot / 12 disks. You can tweak that if you want to make it harder but I actually find this tiny amount makes autocrafting more interesting as you must bulk craft or get rid of excessive cobalt.

If you want to be really evil I suggest requring `14mb` per disc, wich will lead to an uneven number and will make crafting much more annoying.

_This PR did pass ungefroren quality control and is tested._